### PR TITLE
Fix two bugs in auth logic

### DIFF
--- a/src/main/java/net/sourceforge/guacamole/net/auth/userfiles/UserFilesAuthenticationProvider.java
+++ b/src/main/java/net/sourceforge/guacamole/net/auth/userfiles/UserFilesAuthenticationProvider.java
@@ -325,7 +325,7 @@ public class UserFilesAuthenticationProvider implements AuthenticationProvider {
 
         // If no mapping available, report as such
         if (configs == null) {
-            throw new GuacamoleServerException("Configuration could not be read.");
+            return configs;
         } else {
             // Set username if given.
             if (!username.isEmpty()) {
@@ -450,9 +450,19 @@ public class UserFilesAuthenticationProvider implements AuthenticationProvider {
 
         // Return as unauthorized if not authorized to retrieve configs
         if (configs == null) {
-            return null;
+            logger.debug("No config found, trying cookie...");
+            configs = getFilteredAuthorizedConfigurations(authenticatedUser);
+
+            if (configs == null) {
+                logger.debug("No config found, aborting...");
+                return null;
+            }
+
+            logger.debug("Found config with cookie...");
+            return new UserFilesAuthenticationProvider.UserFilesAuthenticatedUser(authenticatedUser.getCredentials(), configs);
         }
 
+        logger.debug("Found config with credentials...");
         return new UserFilesAuthenticationProvider.UserFilesAuthenticatedUser(credentials, configs);
     }
 


### PR DESCRIPTION
1. If user reloads page and does not send credentials but a valid cookie, the session would be terminated.
2. If user connects to a new target, but still has the cookie from the old session, he would end up in the old session.

The new code now uses credentials if present to start a new session. If not it checks for a cookie to resume a session. Only if both are not present, the authentication fails.